### PR TITLE
feat: add Bedrock client integration and new /llm/generate endpoint

### DIFF
--- a/apps/ai-service/src/api/dependencies.py
+++ b/apps/ai-service/src/api/dependencies.py
@@ -1,9 +1,13 @@
 # src/api/dependencies.py
+import boto3
+from botocore.config import Config
 from typing import Generator
 from fastapi import Depends
 from config.settings import settings
 from src.llm.openai_client import OpenAIClient
 from src.llm.claude_client import ClaudeClient
+
+REGION: str = 'eu-west-1'
 
 def get_settings():
     return settings
@@ -15,3 +19,16 @@ def get_openai_client(cfg = Depends(get_settings)) -> Generator[OpenAIClient, No
 def get_claude_client(cfg = Depends(get_settings)) -> Generator[ClaudeClient, None, None]:
     client = ClaudeClient(api_key=cfg.CLAUDE_API_KEY, default_max_tokens=cfg.DEFAULT_MAX_TOKENS)
     yield client
+
+def get_bedrock_client() -> boto3.client:
+    """
+    Create and return a Bedrock client with the specified configuration
+    """
+    config = Config(
+        region_name=REGION,
+        retries={
+            'max_attempts': 3,
+            'mode': 'standard'
+        }
+    )
+    return boto3.client('bedrock-agent-runtime', config=config)

--- a/apps/ai-service/src/api/routes/chat.py
+++ b/apps/ai-service/src/api/routes/chat.py
@@ -2,9 +2,11 @@
 import logging
 
 # Third party imports
+import boto3
 from fastapi import (
     APIRouter,
     HTTPException,
+    Depends,
 )
 from fastapi.responses import StreamingResponse
 
@@ -14,10 +16,111 @@ from src.llm.llm_provider import (
 )
 
 from src.api.interfaces.request_models import ChatRequest
+from src.api.interfaces.response_models import CompletionResponse, ChatResponse
+from src.prompt_engineering.templates import ERGOGLOBAL_AI_SYSTEM_PROMPT
+
+from src.api.dependencies import get_bedrock_client
+
+import boto3
+from botocore.exceptions import (
+    ClientError,
+    EndpointConnectionError,
+    ConnectTimeoutError,
+)
 
 # Initializations
 router = APIRouter()
 logger = logging.getLogger(__name__)
+
+KNOWLEDGE_BASE_ID = "ERJ0GKVEAO"
+MODEL_ARN = "arn:aws:bedrock:eu-west-1:038547062468:inference-profile/eu.anthropic.claude-3-5-sonnet-20240620-v1:0"
+
+
+@router.post("/llm/generate", response_model=ChatResponse, tags=["Chat"])
+async def query_knowledge_base(
+    request_body: ChatRequest,
+    bedrock_client: boto3.client = Depends(get_bedrock_client),
+):
+    try:
+        logger.info(f"Received response generate request: {request_body}")
+
+        bedrock_kwargs = {
+            "input": {"text": request_body.message},
+            "retrieveAndGenerateConfiguration": {
+                "type": "KNOWLEDGE_BASE",
+                "knowledgeBaseConfiguration": {
+                    "knowledgeBaseId": KNOWLEDGE_BASE_ID,
+                    "modelArn": request_body.model or MODEL_ARN,
+                    "retrievalConfiguration": {
+                        "vectorSearchConfiguration": {
+                            "numberOfResults": 5,
+                            "overrideSearchType": "HYBRID",
+                        }
+                    },
+                    "generationConfiguration": {
+                        "promptTemplate": {
+                            "textPromptTemplate": getattr(
+                                request_body, "temperature", ERGOGLOBAL_AI_SYSTEM_PROMPT
+                            ),
+                        },
+                        "inferenceConfig": {
+                            "textInferenceConfig": {
+                                "temperature": getattr(
+                                    request_body, "temperature", 0.0
+                                ),  # Deterministic
+                                "topP": getattr(request_body, "top_p", 0.9),
+                                "maxTokens": getattr(request_body, "max_tokens", 400),
+                            }
+                        },
+                        "performanceConfig": {"latency": "standard"},
+                    },
+                },
+            },
+        }
+
+        if request_body.session_id and request_body.session_id != "string":
+            bedrock_kwargs["sessionId"] = request_body.session_id
+
+        result = bedrock_client.retrieve_and_generate(**bedrock_kwargs)
+
+        output = result.get("output", {}).get("text", "")
+        session_id = result.get("sessionId", "")
+
+        return ChatResponse(reply=output, session_id=session_id)
+
+    except bedrock_client.exceptions.AccessDeniedException:
+        logger.error(f"Bedrock auth error: {str(e)}")
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "error_code": "upstream_auth_error",
+                "message": "Authentication failed with Bedrock",
+            },
+        )
+
+    except EndpointConnectionError as e:
+        logger.error(f"Bedrock connection error: {str(e)}")
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "error_code": "upstream_auth_error",
+                "message": "Cannot connect to Bedrock service",
+            },
+        )
+
+    except ConnectTimeoutError as e:
+        logger.error(f"Bedrock timeout: {str(e)}")
+        raise HTTPException(
+            status_code=504,
+            detail={
+                "error_code": "upstream_timeout",
+                "message": "Bedrock request timed out",
+            },
+        )
+
+    except Exception as e:
+        logger.exception("Unexpected error processing completion request")
+        raise HTTPException(status_code=500, detail=str(e))
 
 
 @router.post("/chat/stream", tags=["Chat"])

--- a/apps/ai-service/src/api/routes/chat.py
+++ b/apps/ai-service/src/api/routes/chat.py
@@ -59,9 +59,11 @@ async def query_knowledge_base(
                     },
                     "generationConfiguration": {
                         "promptTemplate": {
-                            "textPromptTemplate": getattr(
-                                request_body, "temperature", ERGOGLOBAL_AI_SYSTEM_PROMPT
-                            ),
+                            "textPromptTemplate": (
+                                request_body.system_prompt
+                                if request_body.system_prompt
+                                else ERGOGLOBAL_AI_SYSTEM_PROMPT
+                            )
                         },
                         "inferenceConfig": {
                             "textInferenceConfig": {

--- a/apps/ai-service/src/prompt_engineering/templates.py
+++ b/apps/ai-service/src/prompt_engineering/templates.py
@@ -38,3 +38,31 @@ default_system_prompt = """
     - Keep line lengths reasonable for readability
     
     """
+
+
+ERGOGLOBAL_AI_SYSTEM_PROMPT = """
+You are ErgoGlobal's virtual customer support assistant. Your role is to help customers by providing clear, accurate, and professional answers based only on the company’s official information provided in the context below.
+
+Follow these rules:
+- Base all responses strictly on the context provided. 
+- If the information is not in the context, say politely: 
+  "I'm sorry, but I don't have that information right now. Let me connect you with a human support agent for further assistance."
+- Maintain a polite, helpful, and empathetic tone.
+- Use simple, customer-friendly language.
+- Avoid internal jargon or speculation.
+- When listing steps or instructions, use bullet points or numbered lists for clarity.
+
+---
+
+Context:
+$search_results$
+
+---
+
+Customer Question:
+$query$
+
+---
+
+ErgoGlobal Answer:
+"""


### PR DESCRIPTION
This change aims to integrate Bedrock client with /llm/generate endpoint

- Introduces a new function to create a Bedrock client with specific configurations.
- Implements a new POST endpoint `/llm/generate` for generating chat responses using Bedrock.
- Adds error handling for various exceptions related to Bedrock service.
- Defines a new prompt template for the ErgoGlobal virtual customer support assistant.