### PR TITLE
Feat/86c5fwguh/connect chatwoot with fast api webhook

### DIFF
--- a/apps/ai-service/config/settings.py
+++ b/apps/ai-service/config/settings.py
@@ -3,19 +3,28 @@ from pydantic import Field
 from pydantic.v1.env_settings import BaseSettings
 from typing import Optional
 
+
 class AppSettings(BaseSettings):
     API_KEY: str = Field(None, env="API_KEY")
-    ENV: str = Field("development", description="Application environment (development/production/test)")
-    
+    ENV: str = Field(
+        "development",
+        description="Application environment (development/production/test)",
+    )
+
     # API keys
     LLM_API_KEY: Optional[str] = Field(None, env="LLM_API_KEY")
-    
+
+    CHATWOOT_API_ACCESS_TOKEN: str = Field(None, env="CHATWOOT_API_ACCESS_TOKEN")
+
     # Any other environment-based settings
-    DEFAULT_MAX_TOKENS: int = Field(50, description="Default max tokens for completions")
-    
+    DEFAULT_MAX_TOKENS: int = Field(
+        50, description="Default max tokens for completions"
+    )
+
     class Config:
         env_file = ".env"
         env_file_encoding = "utf-8"
+
 
 # Singleton instance
 settings = AppSettings()

--- a/apps/ai-service/src/api/dependencies.py
+++ b/apps/ai-service/src/api/dependencies.py
@@ -1,4 +1,5 @@
 # src/api/dependencies.py
+import logging
 import boto3
 from botocore.config import Config
 from typing import Generator
@@ -7,28 +8,55 @@ from config.settings import settings
 from src.llm.openai_client import OpenAIClient
 from src.llm.claude_client import ClaudeClient
 
-REGION: str = 'eu-west-1'
+REGION: str = "eu-west-1"
+
+logger = logging.getLogger(__name__)
+
 
 def get_settings():
     return settings
 
-def get_openai_client(cfg = Depends(get_settings)) -> Generator[OpenAIClient, None, None]:
-    client = OpenAIClient(api_key=cfg.LLM_API_KEY, default_max_tokens=cfg.DEFAULT_MAX_TOKENS)
-    yield client
 
-def get_claude_client(cfg = Depends(get_settings)) -> Generator[ClaudeClient, None, None]:
-    client = ClaudeClient(api_key=cfg.CLAUDE_API_KEY, default_max_tokens=cfg.DEFAULT_MAX_TOKENS)
-    yield client
-
-def get_bedrock_client() -> boto3.client:
-    """
-    Create and return a Bedrock client with the specified configuration
-    """
-    config = Config(
-        region_name=REGION,
-        retries={
-            'max_attempts': 3,
-            'mode': 'standard'
-        }
+def get_openai_client(cfg=Depends(get_settings)) -> Generator[OpenAIClient, None, None]:
+    client = OpenAIClient(
+        api_key=cfg.LLM_API_KEY, default_max_tokens=cfg.DEFAULT_MAX_TOKENS
     )
-    return boto3.client('bedrock-agent-runtime', config=config)
+    yield client
+
+
+def get_claude_client(cfg=Depends(get_settings)) -> Generator[ClaudeClient, None, None]:
+    client = ClaudeClient(
+        api_key=cfg.CLAUDE_API_KEY, default_max_tokens=cfg.DEFAULT_MAX_TOKENS
+    )
+    yield client
+
+
+def _create_bedrock_client(service_name: str):
+    """
+    Internal helper to create a configured boto3 Bedrock client.
+    """
+    try:
+        config = Config(
+            region_name=REGION,
+            retries={"max_attempts": 3, "mode": "standard"},
+        )
+        client = boto3.client(service_name, config=config)
+        logger.debug(f"Successfully created Bedrock client for {service_name}")
+        return client
+    except Exception as e:
+        logger.error(f"Failed to create Bedrock client for {service_name}: {e}")
+        raise
+
+
+def get_bedrock_runtime_client():
+    """
+    Returns a Bedrock Runtime client for model text generation
+    """
+    return _create_bedrock_client("bedrock-runtime")
+
+
+def get_bedrock_agent_runtime_client():
+    """
+    Returns a Bedrock Agent Runtime client for retrieval from a Knowledge Base
+    """
+    return _create_bedrock_client("bedrock-agent-runtime")

--- a/apps/ai-service/src/api/routes/chat.py
+++ b/apps/ai-service/src/api/routes/chat.py
@@ -7,6 +7,7 @@ import requests
 import boto3
 from fastapi import APIRouter, HTTPException, Depends, Request
 from fastapi.responses import StreamingResponse, JSONResponse
+from config.settings import settings
 
 from src.llm.llm_provider import (
     LLMRequest,
@@ -16,8 +17,14 @@ from src.llm.llm_provider import (
 from src.api.interfaces.request_models import ChatRequest
 from src.api.interfaces.response_models import CompletionResponse, ChatResponse
 
-from src.api.dependencies import get_bedrock_client
-from src.llm.llm_provider import call_bedrock_generate
+from src.api.dependencies import (
+    get_bedrock_runtime_client,
+    get_bedrock_agent_runtime_client,
+)
+from src.llm.llm_provider import (
+    call_bedrock_generate,
+    call_bedrock_generate_with_zero_shot_fallback,
+)
 from src.prompt_engineering.templates import ERGOGLOBAL_AI_SYSTEM_PROMPT
 
 # Initializations
@@ -30,20 +37,21 @@ BASE_URL = (
     "http://ergoglobal-chatwoot-alb-1278403382.eu-west-1.elb.amazonaws.com/api/v1"
 )
 
-CHATWOOT_API_ACCESS_TOKEN = os.getenv("CHATWOOT_API_ACCESS_TOKEN", "")
-
 
 @router.post("/chatwoot/webhook", tags=["Chat"])
 async def chatwoot_webhook(
     request: Request,
-    bedrock_client: boto3.client = Depends(get_bedrock_client),
+    bedrock_runtime_client: boto3.client = Depends(get_bedrock_runtime_client),
+    bedrock_agent_runtime_client: boto3.client = Depends(
+        get_bedrock_agent_runtime_client
+    ),
 ):
     try:
         data = await request.json()
     except Exception:
         raise HTTPException(status_code=400, detail={"error_code": "invalid_payload"})
 
-    if data.get("event") != "message_created" or data.get("event") != "message_updated":
+    if data.get("event") != "message_created":
         return JSONResponse(content={"action": "no_op"}, status_code=200)
 
     try:
@@ -69,21 +77,21 @@ async def chatwoot_webhook(
     except KeyError:
         raise HTTPException(status_code=400, detail={"error_code": "invalid_payload"})
 
-    result = await call_bedrock_generate(
+    result = await call_bedrock_generate_with_zero_shot_fallback(
         query=query,
-        bedrock_client=bedrock_client,
+        bedrock_runtime_client=bedrock_runtime_client,
+        bedrock_agent_runtime_client=bedrock_agent_runtime_client,
         KNOWLEDGE_BASE_ID=KNOWLEDGE_BASE_ID,
         MODEL_ARN=MODEL_ARN,
         PROMPT=ERGOGLOBAL_AI_SYSTEM_PROMPT,
     )
 
-    output = result.get("output", {}).get("text", "")
-    if not output:
-        output = "Sorry, I'm having an issue at the moment. Please try again shortly."
+    if not result:
+        result = "Sorry, I'm having an issue at the moment. Please try again shortly."
 
     url = f"{BASE_URL}/accounts/{account_id}/conversations/{conversation_id}/messages"
-    headers = {"api_access_token": CHATWOOT_API_ACCESS_TOKEN}
-    payload = {"content": output, "message_type": "outgoing", "private": False}
+    headers = {"api_access_token": settings.CHATWOOT_API_ACCESS_TOKEN}
+    payload = {"content": result, "message_type": "outgoing", "private": False}
 
     try:
         response = requests.post(url, headers=headers, json=payload)
@@ -91,28 +99,31 @@ async def chatwoot_webhook(
     except requests.RequestException as e:
         logger.exception("Unexpected error trying to send message from the webhook")
 
-    return JSONResponse(content={"reply": output}, status_code=200)
+    return JSONResponse(content={"reply": result}, status_code=200)
 
 
 @router.post("/llm/generate", response_model=ChatResponse, tags=["Chat"])
 async def query_knowledge_base(
     request_body: ChatRequest,
-    bedrock_client: boto3.client = Depends(get_bedrock_client),
+    bedrock_runtime_client: boto3.client = Depends(get_bedrock_runtime_client),
+    bedrock_agent_runtime_client: boto3.client = Depends(
+        get_bedrock_agent_runtime_client
+    ),
 ):
 
     try:
-        result = await call_bedrock_generate(
+        result = await call_bedrock_generate_with_zero_shot_fallback(
             query=request_body.message,
-            bedrock_client=bedrock_client,
+            bedrock_runtime_client=bedrock_runtime_client,
+            bedrock_agent_runtime_client=bedrock_agent_runtime_client,
             KNOWLEDGE_BASE_ID=KNOWLEDGE_BASE_ID,
             MODEL_ARN=MODEL_ARN,
             PROMPT=ERGOGLOBAL_AI_SYSTEM_PROMPT,
-            session_id=request_body.session_id,
         )
-        output = result.get("output", {}).get("text", "")
-        session_id = result.get("sessionId", "")
 
-        return ChatResponse(reply=output, session_id=session_id)
+        session_id = ""
+
+        return ChatResponse(reply=result, session_id=session_id)
     except Exception as e:
         logger.exception("Unexpected error processing completion request")
         raise HTTPException(status_code=500, detail=str(e))

--- a/apps/ai-service/src/api/routes/chat.py
+++ b/apps/ai-service/src/api/routes/chat.py
@@ -1,14 +1,12 @@
 # System imports
+import os
 import logging
+import requests
 
 # Third party imports
 import boto3
-from fastapi import (
-    APIRouter,
-    HTTPException,
-    Depends,
-)
-from fastapi.responses import StreamingResponse
+from fastapi import APIRouter, HTTPException, Depends, Request
+from fastapi.responses import StreamingResponse, JSONResponse
 
 from src.llm.llm_provider import (
     LLMRequest,
@@ -17,16 +15,10 @@ from src.llm.llm_provider import (
 
 from src.api.interfaces.request_models import ChatRequest
 from src.api.interfaces.response_models import CompletionResponse, ChatResponse
-from src.prompt_engineering.templates import ERGOGLOBAL_AI_SYSTEM_PROMPT
 
 from src.api.dependencies import get_bedrock_client
-
-import boto3
-from botocore.exceptions import (
-    ClientError,
-    EndpointConnectionError,
-    ConnectTimeoutError,
-)
+from src.llm.llm_provider import call_bedrock_generate
+from src.prompt_engineering.templates import ERGOGLOBAL_AI_SYSTEM_PROMPT
 
 # Initializations
 router = APIRouter()
@@ -34,6 +26,72 @@ logger = logging.getLogger(__name__)
 
 KNOWLEDGE_BASE_ID = "ERJ0GKVEAO"
 MODEL_ARN = "arn:aws:bedrock:eu-west-1:038547062468:inference-profile/eu.anthropic.claude-3-5-sonnet-20240620-v1:0"
+BASE_URL = (
+    "http://ergoglobal-chatwoot-alb-1278403382.eu-west-1.elb.amazonaws.com/api/v1"
+)
+
+CHATWOOT_API_ACCESS_TOKEN = os.getenv("CHATWOOT_API_ACCESS_TOKEN", "")
+
+
+@router.post("/chatwoot/webhook", tags=["Chat"])
+async def chatwoot_webhook(
+    request: Request,
+    bedrock_client: boto3.client = Depends(get_bedrock_client),
+):
+    try:
+        data = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail={"error_code": "invalid_payload"})
+
+    if data.get("event") != "message_created" or data.get("event") != "message_updated":
+        return JSONResponse(content={"action": "no_op"}, status_code=200)
+
+    try:
+        account_id = data["account"]["id"]
+        messages = data["conversation"]["messages"]
+        if not messages:
+            raise KeyError("No messages in payload")
+
+        recent_message = messages[0]
+        conversation_id = recent_message["conversation_id"]
+        query = recent_message.get("processed_message_content")
+        message_type = recent_message.get("message_type")
+
+        if not query:
+            raise HTTPException(
+                status_code=400, detail={"error_code": "invalid_payload"}
+            )
+
+        # Ignore if not from user (e.g., message_type != 0 means agent or note)
+        if message_type != 0:
+            return JSONResponse(content={"action": "no_op"}, status_code=200)
+
+    except KeyError:
+        raise HTTPException(status_code=400, detail={"error_code": "invalid_payload"})
+
+    result = await call_bedrock_generate(
+        query=query,
+        bedrock_client=bedrock_client,
+        KNOWLEDGE_BASE_ID=KNOWLEDGE_BASE_ID,
+        MODEL_ARN=MODEL_ARN,
+        PROMPT=ERGOGLOBAL_AI_SYSTEM_PROMPT,
+    )
+
+    output = result.get("output", {}).get("text", "")
+    if not output:
+        output = "Sorry, I'm having an issue at the moment. Please try again shortly."
+
+    url = f"{BASE_URL}/accounts/{account_id}/conversations/{conversation_id}/messages"
+    headers = {"api_access_token": CHATWOOT_API_ACCESS_TOKEN}
+    payload = {"content": output, "message_type": "outgoing", "private": False}
+
+    try:
+        response = requests.post(url, headers=headers, json=payload)
+        response.raise_for_status()
+    except requests.RequestException as e:
+        logger.exception("Unexpected error trying to send message from the webhook")
+
+    return JSONResponse(content={"reply": output}, status_code=200)
 
 
 @router.post("/llm/generate", response_model=ChatResponse, tags=["Chat"])
@@ -41,85 +99,20 @@ async def query_knowledge_base(
     request_body: ChatRequest,
     bedrock_client: boto3.client = Depends(get_bedrock_client),
 ):
+
     try:
-        logger.info(f"Received response generate request: {request_body}")
-
-        bedrock_kwargs = {
-            "input": {"text": request_body.message},
-            "retrieveAndGenerateConfiguration": {
-                "type": "KNOWLEDGE_BASE",
-                "knowledgeBaseConfiguration": {
-                    "knowledgeBaseId": KNOWLEDGE_BASE_ID,
-                    "modelArn": request_body.model or MODEL_ARN,
-                    "retrievalConfiguration": {
-                        "vectorSearchConfiguration": {
-                            "numberOfResults": 5,
-                            "overrideSearchType": "HYBRID",
-                        }
-                    },
-                    "generationConfiguration": {
-                        "promptTemplate": {
-                            "textPromptTemplate": (
-                                request_body.system_prompt
-                                if request_body.system_prompt
-                                else ERGOGLOBAL_AI_SYSTEM_PROMPT
-                            )
-                        },
-                        "inferenceConfig": {
-                            "textInferenceConfig": {
-                                "temperature": getattr(
-                                    request_body, "temperature", 0.0
-                                ),  # Deterministic
-                                "topP": getattr(request_body, "top_p", 0.9),
-                                "maxTokens": getattr(request_body, "max_tokens", 400),
-                            }
-                        },
-                        "performanceConfig": {"latency": "standard"},
-                    },
-                },
-            },
-        }
-
-        if request_body.session_id and request_body.session_id != "string":
-            bedrock_kwargs["sessionId"] = request_body.session_id
-
-        result = bedrock_client.retrieve_and_generate(**bedrock_kwargs)
-
+        result = await call_bedrock_generate(
+            query=request_body.message,
+            bedrock_client=bedrock_client,
+            KNOWLEDGE_BASE_ID=KNOWLEDGE_BASE_ID,
+            MODEL_ARN=MODEL_ARN,
+            PROMPT=ERGOGLOBAL_AI_SYSTEM_PROMPT,
+            session_id=request_body.session_id,
+        )
         output = result.get("output", {}).get("text", "")
         session_id = result.get("sessionId", "")
 
         return ChatResponse(reply=output, session_id=session_id)
-
-    except bedrock_client.exceptions.AccessDeniedException:
-        logger.error(f"Bedrock auth error: {str(e)}")
-        raise HTTPException(
-            status_code=502,
-            detail={
-                "error_code": "upstream_auth_error",
-                "message": "Authentication failed with Bedrock",
-            },
-        )
-
-    except EndpointConnectionError as e:
-        logger.error(f"Bedrock connection error: {str(e)}")
-        raise HTTPException(
-            status_code=502,
-            detail={
-                "error_code": "upstream_auth_error",
-                "message": "Cannot connect to Bedrock service",
-            },
-        )
-
-    except ConnectTimeoutError as e:
-        logger.error(f"Bedrock timeout: {str(e)}")
-        raise HTTPException(
-            status_code=504,
-            detail={
-                "error_code": "upstream_timeout",
-                "message": "Bedrock request timed out",
-            },
-        )
-
     except Exception as e:
         logger.exception("Unexpected error processing completion request")
         raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
This change aims to implement a system story **ChatWoot Connecter** [](https://app.clickup.com/t/86c5fwguh)

- Extracts bedrock calling feature to its own function so that it will be reused 
- Creates a POST webhook end point which will be triggered when messages are created or updated 
- Passes the user message to the bedrock utility function and sends a post request with the result to create a message to this "/accounts/{account_id}/conversations/{conversation_id}/messages" chatwoot backend